### PR TITLE
Add support for changing directories before push

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ jobs:
 | github_token | string | | Token for the repo. Can be passed in using {{ secrets.GITHUB_TOKEN }}'. |
 | branch | string | 'master' | Destination branch to push changes. |
 | force | boolean | false | Determines if force push is used. |
+| directory | string | '.' | Directory to change to before pushing. |
 
 ## License
 

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
   force:
     description: 'Determines if force push is used'
     required: false
+  directory:
+    description: 'Directory to change to before pushing.'
+    required: false
+    default: '.'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/start.sh
+++ b/start.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
+set -e
 
-INPUT_BRANCH:='master'
-INPUT_FORCE:=false
+INPUT_BRANCH=${INPUT_BRANCH:-master}
+INPUT_FORCE=${INPUT_FORCE:-false}
+INPUT_DIRECTORY=${INPUT_DIRECTORY:-'.'}
 _FORCE_OPTION=''
 
 echo "Push to branch $INPUT_BRANCH";
@@ -13,6 +15,11 @@ echo "Push to branch $INPUT_BRANCH";
 if ${INPUT_FORCE}; then
     _FORCE_OPTION='--force'
 fi
+
+cd ${INPUT_DIRECTORY}
+
+# Ensure that the remote of the git repository of the current directory still is the repository where the github action is executed
+git remote add origin https://github.com/${GITHUB_REPOSITORY} || git remote set-url origin https://github.com/${GITHUB_REPOSITORY} || true
 
 header=$(echo -n "ad-m:${INPUT_GITHUB_TOKEN}" | base64)
 git -c http.extraheader="AUTHORIZATION: basic $header" push origin HEAD:${INPUT_BRANCH} --follow-tags $_FORCE_OPTION;


### PR DESCRIPTION
This adds support for changing directories before push.

It also fixes the error `line 5: INPUT_BRANCH:=master: command not found` (introduced at https://github.com/ad-m/github-push-action/pull/4/files#diff-d0b2ef35f4d7cb0284dd5cf566b62f51).

Tested at https://github.com/JabRef/www.jabref.org/runs/243886472