### PR TITLE
Add INPUT_REPOSITORY for another repository push

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ jobs:
 | branch | string | 'master' | Destination branch to push changes. |
 | force | boolean | false | Determines if force push is used. |
 | directory | string | '.' | Directory to change to before pushing. |
+| repository | string | '' | Repository name. Default or empty repository name represents current github repository. |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ jobs:
 
 | name | value | default | description |
 | ---- | ----- | ------- | ----------- |
-| github_token | string | | Token for the repo. Can be passed in using {{ secrets.GITHUB_TOKEN }}'. |
+| github_token | string | | Token for the repo. Can be passed in using `{{ secrets.GITHUB_TOKEN }}`. |
 | branch | string | 'master' | Destination branch to push changes. |
 | force | boolean | false | Determines if force push is used. |
 | directory | string | '.' | Directory to change to before pushing. |
-| repository | string | '' | Repository name. Default or empty repository name represents current github repository. |
+| repository | string | '' | Repository name. Default or empty repository name represents current github repository. If you want to push other repository, you should make a personal access token(https://github.com/settings/tokens) and put it with github_token.  |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ jobs:
 | branch | string | 'master' | Destination branch to push changes. |
 | force | boolean | false | Determines if force push is used. |
 | directory | string | '.' | Directory to change to before pushing. |
-| repository | string | '' | Repository name. Default or empty repository name represents current github repository. If you want to push other repository, you should make a personal access token(https://github.com/settings/tokens) and put it with github_token.  |
+| repository | string | '' | Repository name. Default or empty repository name represents current github repository. If you want to push to other repository, you should make a [personal access token](https://github.com/settings/tokens) and use it as the `github_token` input.  |
 
 ## License
 

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,10 @@ inputs:
   github_token:
     description: 'Token for the repo. Can be passed in using {{ secrets.GITHUB_TOKEN }}'
     required: true
+  repository:
+    description: 'Repository name to push. Default or empty value represents current github repository (${GITHUB_REPOSITORY})'
+    default: ''
+    required: false
   branch:
     description: 'Destination branch to push changes'
     required: false

--- a/start.sh
+++ b/start.sh
@@ -5,6 +5,7 @@ INPUT_BRANCH=${INPUT_BRANCH:-master}
 INPUT_FORCE=${INPUT_FORCE:-false}
 INPUT_DIRECTORY=${INPUT_DIRECTORY:-'.'}
 _FORCE_OPTION=''
+REPOSITORY=${INPUT_REPOSITORY:-$GITHUB_REPOSITORY}
 
 echo "Push to branch $INPUT_BRANCH";
 [ -z "${INPUT_GITHUB_TOKEN}" ] && {
@@ -19,7 +20,7 @@ fi
 cd ${INPUT_DIRECTORY}
 
 # Ensure that the remote of the git repository of the current directory still is the repository where the github action is executed
-git remote add origin https://github.com/${GITHUB_REPOSITORY} || git remote set-url origin https://github.com/${GITHUB_REPOSITORY} || true
+git remote add origin https://github.com/${REPOSITORY} || git remote set-url origin https://github.com/${REPOSITORY} || true
 
 header=$(echo -n "ad-m:${INPUT_GITHUB_TOKEN}" | base64)
 git -c http.extraheader="AUTHORIZATION: basic $header" push origin HEAD:${INPUT_BRANCH} --follow-tags $_FORCE_OPTION;


### PR DESCRIPTION
When I use with another repository pushing, I think that `INPUT_REPOSITORY` is needed. 

```
 - name: push config repository
      uses: ad-m/github-push-action@master
      with:
        github_token: ${{ secrets.GITHUB_PUSH_TOKEN }}
        branch: master
        directory: .
        repository: git/another-repo
```