### PR TITLE
Fix to use REPOSITORY

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -19,6 +19,6 @@ fi
 
 cd ${INPUT_DIRECTORY}
 
-remote_repo="https://${GITHUB_ACTOR}:${INPUT_GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+remote_repo="https://${GITHUB_ACTOR}:${INPUT_GITHUB_TOKEN}@github.com/${REPOSITORY}.git"
 
 git push "${remote_repo}" HEAD:${INPUT_BRANCH} --follow-tags $_FORCE_OPTION;


### PR DESCRIPTION
Replace `GITHUB_REPOSITORY` to `REPOSITORY`. 
