### PR TITLE
Fix start.sh path

### DIFF
--- a/start.js
+++ b/start.js
@@ -1,13 +1,19 @@
 const spawn = require('child_process').spawn;
+const path = require("path");
 
-const main = () => new Promise((resolve, reject) => {
-    const ssh = spawn('bash', ['start.sh'], { stdio: 'inherit' });
-    ssh.on('close', resolve);
-    ssh.on('error', reject);
+const exec = (cmd, args=[]) => new Promise((resolve, reject) => {
+    console.log(`Started: ${cmd} ${args.join(" ")}`)
+    const app = spawn(cmd, args, { stdio: 'inherit' });
+    app.on('close', resolve);
+    app.on('error', reject);
 });
 
+const main = async () => {
+    await exec('bash', [path.join(__dirname, './start.sh')]);
+};
+
 main().catch(err => {
-    console.err(err);
-    console.err(err.stack);
+    console.error(err);
+    console.error(err.stack);
     process.exit(-1);
 })


### PR DESCRIPTION
close #30 

@simon300000, @Veloxious, could you verify?

Use for example as:
```yaml
    - uses: ad-m/git-push-action@fix-start-sh
      with:
        github_token: ${{ secrets.GITHUB_TOKEN }}
```
