### PR TITLE
refactor(start): use @actions/exec

### DIFF
--- a/start.js
+++ b/start.js
@@ -1,26 +1,12 @@
-const spawn = require('child_process').spawn;
+const exec = require("@actions/exec");
 const path = require("path");
 
-const exec = (cmd, args=[]) => new Promise((resolve, reject) => {
-    console.log(`Started: ${cmd} ${args.join(" ")}`)
-    const app = spawn(cmd, args, { stdio: 'inherit' });
-    app.on('close', code => {
-        if(code !== 0){
-            err = new Error(`Invalid status code: ${code}`);
-            err.code = code;
-            return reject(err);
-        };
-        return resolve(code);
-    });
-    app.on('error', reject);
-});
-
 const main = async () => {
-    await exec('bash', [path.join(__dirname, './start.sh')]);
+  await exec(path.join(__dirname, "./start.sh"));
 };
 
 main().catch(err => {
-    console.error(err);
-    console.error(err.stack);
-    process.exit(err.code || -1);
-})
+  console.error(err);
+  console.error(err.stack);
+  process.exit(err.code || -1);
+});


### PR DESCRIPTION
Hi.

Good action :)

I refactored a little. Refer to [@actions/exec](https://github.com/actions/toolkit/tree/master/packages/exec) for more detail. As you can see in [this line](https://github.com/actions/toolkit/blob/54bcb7c4f1a53c3c6022f4f5e8be67b8fcf23462/packages/exec/src/exec.ts#L12), it returns a promise of exit code. 

So, if you'd like to accept this PR, you should write an error handling(e.g. `if(exitCode !== 0){ }`), and test the final code.

Otherwise, you might consider using a node's built-in function `child_process.exec` instead of `@actions/exec`.

Cheers.