### PR TITLE
Use @v2 instead of @master in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
       with:
         persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
         fetch-depth: 0 # otherwise, you will failed to push refs to dest repo


### PR DESCRIPTION
Thanks for creating this action. Works great!

Just a suggestion that it'd be better to use `actions/checkout@v2` instead of `@master` in the Readme, for stability. That's Github's current recommendation.