### PR TITLE
Revert "refactor(start): use @actions/exec"

### DIFF
--- a/start.js
+++ b/start.js
@@ -1,12 +1,26 @@
-const exec = require("@actions/exec");
+const spawn = require('child_process').spawn;
 const path = require("path");
 
+const exec = (cmd, args=[]) => new Promise((resolve, reject) => {
+    console.log(`Started: ${cmd} ${args.join(" ")}`)
+    const app = spawn(cmd, args, { stdio: 'inherit' });
+    app.on('close', code => {
+        if(code !== 0){
+            err = new Error(`Invalid status code: ${code}`);
+            err.code = code;
+            return reject(err);
+        };
+        return resolve(code);
+    });
+    app.on('error', reject);
+});
+
 const main = async () => {
-  await exec(path.join(__dirname, "./start.sh"));
+    await exec('bash', [path.join(__dirname, './start.sh')]);
 };
 
 main().catch(err => {
-  console.error(err);
-  console.error(err.stack);
-  process.exit(err.code || -1);
-});
+    console.error(err);
+    console.error(err.stack);
+    process.exit(err.code || -1);
+})


### PR DESCRIPTION
Reverts ad-m/github-push-action#47

It add build unnecesary build complexity as introduce new dependency. Adding any new dependency require build step via `vercel/ncc` due GitHub Actions Javascript action limitation.

CC: @jjangga0214