### PR TITLE
Document the new default branch in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ jobs:
 | name | value | default | description |
 | ---- | ----- | ------- | ----------- |
 | github_token | string | | Token for the repo. Can be passed in using `${{ secrets.GITHUB_TOKEN }}`. |
-| branch | string | master | Destination branch to push changes. Can be passed in using `${{ github.ref }}`. |
+| branch | string | main | Destination branch to push changes. Can be passed in using `${{ github.ref }}`. |
 | force | boolean | false | Determines if force push is used. |
 | tags | boolean | false | Determines if `--tags` is used. |
 | directory | string | '.' | Directory to change to before pushing. |


### PR DESCRIPTION
This threw be off a little, but in https://github.com/ad-m/github-push-action/pull/69 the readme wasn't updated to document the new default branch.

This updates it to have the new default value of `main` :)