### PR TITLE
Fixed usage of ref instead of head_ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ With ease:
 An example workflow to authenticate with GitHub Platform:
 
 ```yaml
+on:
+  push:
+    branches:
+      - main
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -36,8 +41,28 @@ jobs:
       uses: ad-m/github-push-action@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: ${{ github.ref }}
+```
+
+> NOTE: For `pull_request` events change `${{ github.ref }}` -> `${{ github.head_ref }}`
+
+**Example**
+
+```yaml
+
+on:
+  pull_request:
+    branches:
+      - main
+
+...
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
         branch: ${{ github.head_ref }}
 ```
+
 
 ### Inputs
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ jobs:
       uses: ad-m/github-push-action@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        branch: ${{ github.ref }}
+        branch: ${{ github.head_ref }}
 ```
 
 ### Inputs


### PR DESCRIPTION
Resolves bug with using `github.ref`

**SETUP**
```yaml
      - name: Push changes
        uses: ad-m/github-push-action@master
        with:
          github_token: ${{ secrets.GITHUB_TOKEN }}
          branch: ${{ github.ref }}
```

![Screen Shot 2021-01-07 at 1 54 41 AM](https://user-images.githubusercontent.com/17484350/103861902-19987f00-508c-11eb-8469-04ddf2051c77.png)


**ERROR**
![Screen Shot 2021-01-07 at 1 55 07 AM](https://user-images.githubusercontent.com/17484350/103861441-6d569880-508b-11eb-892d-d5166311f192.png)

Switching to `github.base_ref` fixed the issue

```yaml
      - name: Push changes
        uses: ad-m/github-push-action@master
        with:
          github_token: ${{ secrets.GITHUB_TOKEN }}
          branch: ${{ github.base_ref }}
```

![Screen Shot 2021-01-07 at 1 59 52 AM](https://user-images.githubusercontent.com/17484350/103861856-100f1700-508c-11eb-9ff4-b7f1a7251f2b.png)

@ad-m 