### PR TITLE
Add deploy key functionality

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,18 +1,20 @@
 name: Action CI
 
-on: [push]
+on:
+  push:
+    branches: [master, main]
 
 jobs:
 
   build:
- 
+
     runs-on: ubuntu-latest
- 
+
     steps:
-    - uses: actions/checkout@master
-    - name: Verify action syntax 
-      # The action should not publish any real changes, but should succeed.
-      uses: './'
-      with:
-        github_token: '${{ secrets.GITHUB_TOKEN }}'
-        branch: '${{ github.ref }}'
+      - uses: actions/checkout@master
+      - name: Verify action syntax
+        # The action should not publish any real changes, but should succeed.
+        uses: './'
+        with:
+          github_token: '${{ secrets.GITHUB_TOKEN }}'
+          branch: '${{ github.ref }}'

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ jobs:
       uses: ad-m/github-push-action@master
       with:
         branch: ${{ github.ref }}
+	ssh: true
 ```
 
 ### Inputs

--- a/README.md
+++ b/README.md
@@ -39,16 +39,41 @@ jobs:
         branch: ${{ github.ref }}
 ```
 
+An example workflow to authenticate with GitHub Platform via Deploy Keys or in general SSH:
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+    - name: Create local changes
+      run: |
+        ...
+    - name: Commit files
+      run: |
+        git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config --local user.name "github-actions[bot]"
+        git commit -m "Add changes" -a
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        branch: ${{ github.ref }}
+```
+
 ### Inputs
 
-| name | value | default | description |
-| ---- | ----- | ------- | ----------- |
-| github_token | string |  `${{ github.token }}` | [GITHUB_TOKEN](https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow#using-the-github_token-in-a-workflow) <br /> or a repo scoped <br /> [Personal Access Token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token). |
-| branch | string | (default) | Destination branch to push changes. <br /> Can be passed in using `${{ github.ref }}`. |
-| force | boolean | false | Determines if force push is used. |
-| tags | boolean | false | Determines if `--tags` is used. |
-| directory | string | '.' | Directory to change to before pushing. |
-| repository | string | '' | Repository name. <br /> Default or empty repository name represents <br /> current github repository. <br /> If you want to push to other repository, <br /> you should make a [personal access token](https://github.com/settings/tokens) <br /> and use it as the `github_token` input.  |
+| name | value   | default | description                                                                                                                                                                                                                                                                                                                   |
+| ---- |---------| ------- |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| github_token | string  |  `${{ github.token }}` | [GITHUB_TOKEN](https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow#using-the-github_token-in-a-workflow) <br /> or a repo scoped <br /> [Personal Access Token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token). |
+| ssh | boolean | false | Determines if ssh is used.                                                                                                                                                                                                                                                                                                    |
+| branch | string  | (default) | Destination branch to push changes. <br /> Can be passed in using `${{ github.ref }}`.                                                                                                                                                                                                                                        |
+| force | boolean | false | Determines if force push is used.                                                                                                                                                                                                                                                                                             |
+| tags | boolean | false | Determines if `--tags` is used.                                                                                                                                                                                                                                                                                               |
+| directory | string  | '.' | Directory to change to before pushing.                                                                                                                                                                                                                                                                                        |
+| repository | string  | '' | Repository name. <br /> Default or empty repository name represents <br /> current github repository. <br /> If you want to push to other repository, <br /> you should make a [personal access token](https://github.com/settings/tokens) <br /> and use it as the `github_token` input.                                     |
 
 ## License
 

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,14 @@ inputs:
     description: 'GitHub token or PAT token'
     required: true
     default: ${{ github.token }}
+  github_url:
+    description: 'GitHub url or GitHub Enterprise url'
+    required: true
+    default: ${{ github.server_url }}
+  ssh:
+    description: 'Specify if ssh should be used'
+    required: false
+    default: ''
   repository:
     description: 'Repository name to push. Default or empty value represents current github repository (${GITHUB_REPOSITORY})'
     default: ''

--- a/start.js
+++ b/start.js
@@ -42,12 +42,14 @@ const trim = (value, charlist) => trimLeft(trimRight(value, charlist));
 const main = async () => {
     let branch = process.env.INPUT_BRANCH;
     const repository = trim(process.env.INPUT_REPOSITORY || process.env.GITHUB_REPOSITORY);
+    const github_url_protocol = trim(process.env.INPUT_GITHUB_URL).split("//")[0];
+    const github_url = trim(process.env.INPUT_GITHUB_URL).split("//")[1];
     if (!branch) {
         const headers = {
             'User-Agent': 'github.com/ad-m/github-push-action'
         };
         if (process.env.INPUT_GITHUB_TOKEN) headers.Authorization = `token ${process.env.INPUT_GITHUB_TOKEN}`;
-        const body = JSON.parse(await get(`https://api.github.com/repos/${repository}`, { headers }))
+        const body = JSON.parse(await get(`${process.env.GITHUB_API_URL}/repos/${repository}`, { headers }))
         branch = body.default_branch;
     }
     await exec('bash', [path.join(__dirname, './start.sh')], {
@@ -55,6 +57,8 @@ const main = async () => {
             ...process.env,
             INPUT_BRANCH: branch,
             INPUT_REPOSITORY: repository,
+            INPUT_GITHUB_URL_PROTOCOL: github_url_protocol,
+            INPUT_GITHUB_URL: github_url,
         }
     });
 };

--- a/start.sh
+++ b/start.sh
@@ -23,6 +23,12 @@ fi
 
 cd ${INPUT_DIRECTORY}
 
-remote_repo="https://${GITHUB_ACTOR}:${INPUT_GITHUB_TOKEN}@github.com/${REPOSITORY}.git"
+if ${INPUT_SSH}; then
+    remote_repo="git@${INPUT_GITHUB_URL}:${REPOSITORY}.git"
+else
+    remote_repo="${INPUT_GITHUB_URL_PROTOCOL}//${GITHUB_ACTOR}:${INPUT_GITHUB_TOKEN}@${INPUT_GITHUB_URL}/${REPOSITORY}.git"
+fi
+
+git config --local --add safe.directory ${INPUT_DIRECTORY}
 
 git push "${remote_repo}" HEAD:${INPUT_BRANCH} --follow-tags $_FORCE_OPTION $_TAGS;


### PR DESCRIPTION
The corresponding PR adds in general support for the SSH Key functionality and solve the [following](https://github.com/ad-m/github-push-action/issues/110) issue.

@ad-m Could we test the first version via a dev release? I want to consume the new dev release via this [test job](https://github.com/ZPascal/grafana_dashboard_templater/pull/7) to validate the functionality.