### PR TITLE
Use node16 to run action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,5 +40,5 @@ inputs:
     required: false
     default: '.'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'start.js'


### PR DESCRIPTION
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.