### PR TITLE
Remove the user from the URL string

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,31 @@ jobs:
         force_with_lease: true
 ```
 
+An example workflow to use the non default token push to another repository. Be aware that the force-with-lease flag is in such a case not possible:
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.head_ref }}
+        fetch-depth: 0
+        token: ${{ secrets.PAT_TOKEN }}
+    - name: Commit files
+      run: |
+        git config --local user.email "github-actions[bot]@users.noreply.github.com"
+        git config --local user.name "github-actions[bot]"
+        git commit -a -m "Add changes"
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ secrets.PAT_TOKEN }}
+        repository: Test/test
+        force: true
+```
+
 An example workflow to update/ overwrite an existing tag:
 
 ```yaml

--- a/start.sh
+++ b/start.sh
@@ -43,7 +43,7 @@ cd ${INPUT_DIRECTORY}
 if ${INPUT_SSH}; then
     remote_repo="git@${INPUT_GITHUB_URL}:${REPOSITORY}.git"
 else
-    remote_repo="${INPUT_GITHUB_URL_PROTOCOL}//${GITHUB_ACTOR}:${INPUT_GITHUB_TOKEN}@${INPUT_GITHUB_URL}/${REPOSITORY}.git"
+    remote_repo="${INPUT_GITHUB_URL_PROTOCOL}//oauth2:${INPUT_GITHUB_TOKEN}@${INPUT_GITHUB_URL}/${REPOSITORY}.git"
 fi
 
 git config --local --add safe.directory ${INPUT_DIRECTORY}


### PR DESCRIPTION
# **Issue:**
fix: #167 & #164

# **Reproduced case:**
https://github.com/ZPascal/test_clone_push_action/actions/runs/5033581950/jobs/9027893083#step:4:10

# **Solution:**
Change the used "user" to oauth2.

# **Test cases:**
## **GitHub Token**
https://github.com/ZPascal/test_clone_push_action/actions/runs/5034026984/jobs/9028601552

## **PAT**
https://github.com/ZPascal/test_clone_push_action/actions/runs/5034047888/jobs/9028633417

