### PR TITLE
Update start.js

### DIFF
--- a/start.js
+++ b/start.js
@@ -1,9 +1,10 @@
 'use strict';
 const spawn = require('child_process').spawn;
 const path = require("path");
+const http = require('http');
 const https = require('https');
 
-const get = (url, options = {}) => new Promise((resolve, reject) => https
+const get = (url, options = {}) => new Promise((resolve, reject) => ((url.protocol == "https:") ? https : http)
     .get(url, options, (res) => {
         const chunks = [];
         res.on('data', (chunk) => chunks.push(chunk));


### PR DESCRIPTION
Compatible with repository addresses using http protocol.

I am using this action on my company's internal `Gitea` platform.   
Exposed this issue, this PR was tested locally to fix this issue.   
`Gitea` is a Github-like product that can be deployed on a company's local area network(Our internal Gitea instance uses the http protocol.). He implemented a set of fully compatible Github Actions with reference to Github Actions, so we can also use github-push-action; 