### PR TITLE
Upgrade Node.js version from 20 to 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,5 +47,5 @@ inputs:
     required: false
     default: '.'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'start.js'


### PR DESCRIPTION
Replace Node 20 with 24. 

This action has started to generate warnings about Node 20 being deprecated. See: [Deprecation of Node 20 on GitHub Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

